### PR TITLE
HTTPS the /metrics endpoint 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 test/test_reports/**/**/*
+tls

--- a/README.md
+++ b/README.md
@@ -1,57 +1,10 @@
-# Docker image of Protractor with headless Chrome
+# Web console smoke test container
 
-## Run locally
+This container image uses `protractor` to run smoke tests against the web console
+at a default or specified `interval`, exposing the results via `/metrics` with the
+assumption that this data will be scraped and used by `prometheus`.
 
-This will run protractor against Chrome allowing you to see the tests:
-
-```bash
-cd test
-yarn install
-$(yarn bin)/webdriver-manager update
-CONSOLE_URL=https://<machine-ip>:8443 $(yarn bin)/protractor protractor.conf.js
-# additionally, you can use the following environment variables
-CONSOLE_URL=https://<machine-ip>:8443 \
-  # If you are not running in a container within Openshift/Kubernetes,
-  # you will need to provide a token or run the oauth flow as the
-  # service account token will not exist.  The service account token
-  # is read from disk in these environments.
-  TOKEN=<some-token> \
-  # don't use TOKEN + CONSOLE_USER CONSOLE_PASSWORD
-  CONSOLE_USER=<some-username-for-oauth> \
-  CONSOLE_PASSWORD=<some-password-for-oauth> \
-  $(yarn bin)/protractor protractor.conf.js
-```
-
-## Build the container
-
-```bash
-$ ./docker_build.sh
-# or
-$ docker build -t openshift-web-console-smoke-test .
-```
-
-# Run the tests in a container
-
-```bash
-$ CONSOLE_URL=https://<machine-ip>:8443 ./docker_run.sh
-# or
-$ docker run -it --rm -e CONSOLE_URL=https://<machine-ip>:8443 openshift-web-console-smoke-test
-```
-
-# Debug from within the container
-
-```bash
-$ ./docker_debug.sh
-# then, in the container:
-# $ CONSOLE_URL=https://<machine-ip>:8443 protractor protractor.conf.js
-# or
-$ docker run -it --rm -e CONSOLE_URL=https://<machine-ip>:8443 --entrypoint /bin/bash openshift-web-console-smoke-test
-$ protractor protractor.conf.js
-```
-
-Based on [Docker Protractor Headless](https://github.com/jciolek/docker-protractor-headless)
-
-## Deploying on openshift
+## Running on a production cluster
 
 Create an `openshift-*` namespace for the container to run in. You will need to do this as cluster admin as
 `openshift-*` is reserved:
@@ -60,18 +13,14 @@ Create an `openshift-*` namespace for the container to run in. You will need to 
 oc create namespace openshift-console-smoke-test
 ```
 
-Next, use `/kube/pods/smoke-test.yaml` to deploy the image within this namespace.  Be sure to update the
-`CONSOLE_URL` environment variable to point to the correct IP address:
+next, use the `/openshift/smoke-test.yaml` template to deploy the smoke tests:
 
-```yaml
-containers:
-- name: openshift-web-console-smoke-test
-  image: benjaminapetersen/openshift-web-console-smoke-test:latest
-  imagePullPolicy: Always
-  env:
-  # update the IP to <machine-ip>, wherever the console is running
-  - name: CONSOLE_URL
-    value: https://<machine-ip>:8443
+```bash
+oc process \
+  -f openshift/smoke-test.yaml \
+  NAMESPACE=<a-valid-namespace> \
+  IMAGE=<image> \
+  CONSOLE_URL=<url-or-ip-for-console> | oc create -f -
 ```
 
 ## Running tests
@@ -82,16 +31,23 @@ The origin smoke tests are running periodically, every 5 minutes. To override th
 
 [Prom Client](https://github.com/siimon/prom-client) for Node.js is used to collect metrics.
 
-There is a server.js file in this repository, it can be run with:
+The file `/test/server.js` is responsible for creating the `/metrics` endpoint.  To
+run it locally to review the output do the following:
 
 ```bash
-node server.js
+cd test
+yarn install
+# note: the endpoint uses https and expects certificate files.
+# you can generate some via the make_dev_crt.sh file
+KEY_PATH=/path/to/key.pem \
+ CRT_PATH=/path/to/crt.pem \
+ node server.js
 ```
 
 This will start a server listening at `http://localhost:3000/metrics`.  When this endpoint
 is hit, via a browser or otherwise, a txt file like the following will be returned:
 
-```
+```bash
 # lots of default metrics...
 # followed by:
 #
@@ -115,16 +71,165 @@ However, this is still not automatic.
 
 TODO: figure out what else is needed to get prometheus to hit this endpoint.
 
+## Local Environment
 
-### TODO for metrics:
+You will need to test against a running cluster. Minishift is a simple way to do this
+locally.  Follow the [installation instructions](https://github.com/minishift/minishift) for
+minishift for your OS, then do the following:
 
-This is implemented as a prometheus Counter.  It is a proof of concept only. Some things we need
-to decide:
+```bash
+minishift start
+# take note of the console url when opened,
+# you will need to use it as an environment variable below
+minishift console
+```
 
-- how often should these smoke tests run? only on upgrades?  constantly?
-- what is the most meaningful metric to gather?
+## Running locally with the Openshift Template
 
-In addition, there is probably a better way to stitch together `protractor` to the `/metrics`
-endpoint.  Currently this just reads the JUNIT `xml` file & looks for `failures: 0` on
-each of the `testsuite` entries.  We could write a custom reporter to simplify this &
-eliminate the need to read the XML file.
+This is the recommended way to run the smoke test image built from this repository.
+
+```bash
+# oc process looks something like this:
+oc process \
+  -f openshift/smoke-test.yaml \
+  NAMESPACE=<a-valid-namespace> \
+  IMAGE=<image> \
+  CONSOLE_URL=<url-or-ip-for-console> | oc create -f -
+
+# full example:
+oc process \
+  -f openshift/smoke-test.yaml \
+  NAMESPACE=test-namespace-1 \
+  IMAGE=web-console-smoke-test:latest \
+  CONSOLE_URL=https://192.168.64.3:8443 | oc create -f -
+```
+
+
+## Running with the YAML files
+
+Alternatively, you can manually setup the smoke tests with the yaml files in the `/kube`
+directory of this repository.  You will have to make a copy and tweak some of the
+environment variables to fit your needs.
+
+```bash
+# first you will need a new namespace:
+oc new-project <project-name>
+# create certificates for the /metrics endpoint
+#./make_dev_crt.sh
+# store the certs in a secret
+# oc create secret tls --cert ./tls/cert.pem --key ./tls/key.pem -o yaml
+#
+
+# create the service first, this contains an annotation to generate a
+# certificate that will also be used by the deployment
+oc create -f kube/service/smoke-test.yaml
+# create the deployment
+# be sure to check the env vars in the yaml file
+# CONSOLE_URL will almost certainly need to be updated
+oc create -f kube/deployments/smoke-test.yaml
+# alternatively you could just create the pod
+oc create -f kube/pods/smoke-test.yaml
+```
+
+If you need to manually provide a secret, you can do something like:
+
+```bash
+./make_dev_crt.sh
+oc create secret tls --cert ./tls/cert.pem --key ./tls/key.pem -o yaml
+# edit the deployment/smoke-test.yaml to reference the created
+# secret rather than use the one that would be provided by the
+# service annotation
+oc create -f kube/deployments/smoke-test.yaml
+
+```
+
+
+
+## Running locally with Docker
+
+For a fast development workflow while still working with the container, you can
+use Docker:
+
+- building
+  - `./docker_build.sh` is easiest
+    - to build with a specific tag (default `latest`) or specify container name:
+      - `TAG=v0.0.1 ./docker_build.sh`
+      - `CONTAINER_NAME=new-name ./docker_build.sh`
+
+- pushing
+  - `./docker_push.sh` is provided, but you must provide a username for the repository:
+    - `USERNAME=openshift ./docker_push.sh`
+    - results in:
+    - `docker push openshift/web-console-smoke-test:latest`
+
+- running
+  - this is probably the fastest way to test locally
+  - you will need to provide certificates for https for the metrics endpoint
+    - `./make_dev_certs.sh` will generate certs at `./tls/`
+  - you will also need to provide a token (such as an OAuth token) for the
+    tests to login to the web console.
+    - the simplest way to do this is to manually login to your dev cluster
+      via the web console, then do one of the following:
+      - Click your username in the top right corner and then select "Copy Login Command".
+        Use this token from your clipboard
+      - Alternatively, you can open the developer console in your browser after
+        login and copy `LocalStorageUserStore.token` from LocalStorage.
+  - then run `./docker_run.sh` like this:
+    `CONSOLE_URL=<console-url> TOKEN=<token-string> ./docker_run.sh`
+  - a full example:
+    `CONSOLE_URL=https://192.168.64.3:8443 TOKEN=UC2YKiub0Wf8lrgitp1kCNi_sTk3lt-YGB83T5Vzs0s ./docker_run.sh`
+
+
+## Running locally
+
+Finally, the tests can be run locally without using a container by doing the following:
+
+```bash
+cd /test
+# the last "scripts" block of the package.json file contains some useful scripts
+tail -n 15
+# you can use "yarn" to run any of these scripts
+CONSOLE_URL=<console-url> TOKEN=<token> yarn test:run_once
+# a full example:
+CONSOLE_URL=https://192.168.64.3:8443 \
+  TOKEN=UC2YKiub0Wf8lrgitp1kCNi_sTk3lt-YGB83T5Vzs0s \
+  yarn test:run_once
+```
+
+You can optionally provide a `CONSOLE_USER` and `CONSOLE_PASSWORD` if
+you want to run the tests with an OAuth flow.  It is recommended you
+are familiar with `protractor` and can read the `/test/protractor.conf.js`
+file and understand test files / suites to do this.
+
+An example may look like:
+
+
+```bash
+cd /test
+CONSOLE_URL=https://<machine-ip>:8443 \
+  TOKEN=<some-token> \
+  CONSOLE_USER=<some-username-for-oauth> \
+  CONSOLE_PASSWORD=<some-password-for-oauth> \
+  $(yarn bin)/protractor protractor.conf.js
+```
+
+## Check the /metrics endpoint
+
+If you need to verify that the metrics endpoint is working properly, you can do something like:
+
+```bash
+# assuming you are using minishift to start a local cluster
+minishift start
+minishift ssh
+# find the <container-id> of your running smoke tests
+docker ps                            
+docker exec -it <container-id> /bin/bash
+# should return metrics information
+curl --insecure https://localhost:3000/metrics
+```
+
+
+
+
+
+  

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -3,4 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-docker build -t openshift-web-console-smoke-test .
+CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
+TAG=${TAG:-latest}
+
+echo "building ${CONTAINER_NAME}:${TAG}"
+
+docker build -t "${CONTAINER_NAME}:${TAG}" "${PWD}"

--- a/docker_debug.sh
+++ b/docker_debug.sh
@@ -4,9 +4,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "Run the following:"
-echo "$ CONSOLE_URL=<url> protractor protractor.conf.js"
+CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
+TAG=${TAG:-latest}
+
+echo ""
+echo "debug ${CONTAINER_NAME}:${TAG}"
+echo ""
+echo "-------------------------------------------------"
+# once you enter the container, you will run the following
+# commands to manually debug the test:
+echo "To manually debug, run one of the following:"
+echo "- To use the oauth flow:"
+echo "  $ CONSOLE_URL=<url> protractor protractor.conf.js"
+echo "- To use an oauth token and bypass the oauth flow:"
+echo "  $ CONSOLE_URL=<url> TOKEN=<your-token> protractor protractor.conf.js"
+echo "-------------------------------------------------"
+echo ""
 
 docker run -it --rm \
-  -e CONSOLE_URL=${CONSOLE_URL} \
-  --entrypoint /bin/bash openshift-web-console-smoke-test
+  --entrypoint /bin/bash "${CONTAINER_NAME}:${TAG}"

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
+TAG=${TAG:-latest}
+USERNAME=${USERNAME:-benjaminapetersen}
+
+echo "container: ${CONTAINER_NAME}"
+echo "user: ${USERNAME}"
+echo "hub: ${USERNAME}/${CONTAINER_NAME}"
+echo "image: ${USERNAME}/${CONTAINER_NAME}:${TAG}"
+echo "tag: ${CONTAINER_NAME} ${USERNAME}/${CONTAINER_NAME}:${TAG}"
+echo "working dir: ${PWD}"
+
+docker build -t "${CONTAINER_NAME}:${TAG}" "${PWD}"
+docker tag "${CONTAINER_NAME}" "${USERNAME}/${CONTAINER_NAME}:${TAG}"
+docker push "${USERNAME}/${CONTAINER_NAME}:${TAG}"

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -7,6 +7,12 @@ CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
 TAG=${TAG:-latest}
 USERNAME=${USERNAME:-benjaminapetersen}
 
+if [ -z "$USERNAME" ]; then
+  echo "The environment variable USERNAME must be set to push to your repository."
+  echo "<USERNAME>/${CONTAINER_NAME}:${TAG}"
+  exit 1
+fi
+
 echo "container: ${CONTAINER_NAME}"
 echo "user: ${USERNAME}"
 echo "hub: ${USERNAME}/${CONTAINER_NAME}"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -7,7 +7,9 @@
 CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
 TAG=${TAG:-latest}
 
-CERTS_PATH="${PWD}/tls/"
+CERTS_PATH="${PWD}/tls"
+KEY_PATH="${CERTS_PATH}/key.pem"
+CRT_PATH="${CERTS_PATH}/crt.pem"
 
 if [ -z "$CONSOLE_URL" ]; then
   echo "The environment variable CONSOLE_URL must be set."
@@ -17,14 +19,22 @@ else
 fi
 
 if [ -z "$(ls -A ${CERTS_PATH})" ]; then
-  echo "The path ${CERTS_PATH} must contain your certs. Run ./make_cert.sh."
+  echo "The path ${CERTS_PATH} must contain your certs. Run ./make_dev_cert.sh."
+  echo "these files will be mounted into your container to secure the /metrics endpoint."
   exit 1
 fi
+
+if [ -z "$TOKEN" ]; then
+  echo "You must provide a TOKEN for tests to access the web console."
+  echo "An OAuth token is sufficient"
+  exit 1
+fi
+
 
 # NOTE: token may have been passed as a string or
 # have been read from disk.
 docker run -it --rm \
-  --mount src=${PWD}/tls/,target=/etc/tls-certs,readonly,type=bind \
+  --mount src=${CERTS_PATH},target=/etc/tls-certs,readonly,type=bind \
   -e CONSOLE_URL=${CONSOLE_URL}  \
   -e CONSOLE_USER=${CONSOLE_USER} \
   -e CONSOLE_PASSWORD=${CONSOLE_PASSWORD} \

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -4,6 +4,11 @@
 #set -o nounset
 #set -o pipefail
 
+CONTAINER_NAME=${CONTAINER_NAME:-web-console-smoke-test}
+TAG=${TAG:-latest}
+
+CERTS_PATH="${PWD}/tls/"
+
 if [ -z "$CONSOLE_URL" ]; then
   echo "The environment variable CONSOLE_URL must be set."
   exit 1
@@ -11,6 +16,19 @@ else
   echo "The CONSOLE_URL is to $CONSOLE_URL"
 fi
 
+if [ -z "$(ls -A ${CERTS_PATH})" ]; then
+  echo "The path ${CERTS_PATH} must contain your certs. Run ./make_cert.sh."
+  exit 1
+fi
+
+# NOTE: token may have been passed as a string or
+# have been read from disk.
 docker run -it --rm \
+  --mount src=${PWD}/tls/,target=/etc/tls-certs,readonly,type=bind \
   -e CONSOLE_URL=${CONSOLE_URL}  \
-  openshift-web-console-smoke-test
+  -e CONSOLE_USER=${CONSOLE_USER} \
+  -e CONSOLE_PASSWORD=${CONSOLE_PASSWORD} \
+  -e TOKEN=${TOKEN} \
+  -e KEY_PATH=${KEY_PATH} \
+  -e CRT_PATH=${CRT_PATH} \
+  "${CONTAINER_NAME}:${TAG}"

--- a/kube/deployments/smoke-test.yaml
+++ b/kube/deployments/smoke-test.yaml
@@ -1,28 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: openshift-web-console-smoke-test-deployment
+  name: web-console-smoke-test-deployment
   labels:
-    app: openshift-web-console-smoke-test
+    app: web-console-smoke-test
 spec:
   # replica set
   replicas: 1
   # selector = how the deployment finds pods to manage
   selector:
     matchLabels:
-      app: openshift-web-console-smoke-test
+      app: web-console-smoke-test
   template:
     metadata:
       labels:
-        app: openshift-web-console-smoke-test
+        app: web-console-smoke-test
     spec:
       containers:
-      - name: openshift-web-console-smoke-test
-        image: benjaminapetersen/openshift-web-console-smoke-test:latest
+      - name: web-console-smoke-test
+        image: benjaminapetersen/web-console-smoke-test:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: CONSOLE_URL
-          value: https://10.192.213.145:8443
+          value: https://192.168.64.3:8443
         - name: CONSOLE_USER
           value: bob
         - name: CONSOLE_PASSWORD
@@ -32,3 +32,12 @@ spec:
         ports:
         - containerPort: 3000
         restartPolicy: Always
+        volumeMounts:
+          - mountPath: /etc/tls-certs
+            name: web-console-smoke-test-serving-cert
+            readOnly: true
+      volumes:
+      - name: web-console-smoke-test-serving-cert
+        secret:
+          defaultMode: 400
+          secretName: web-console-smoke-test-serving-cert

--- a/kube/pods/smoke-test.yaml
+++ b/kube/pods/smoke-test.yaml
@@ -1,21 +1,30 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: openshift-web-console-smoke-test-pod
+  name: web-console-smoke-test-pod
   labels:
-    app: openshift-web-console-smoke-test
+    app: web-console-smoke-test
 spec:
   restartPolicy: Never
   containers:
-  - name: openshift-web-console-smoke-test
-    image: benjaminapetersen/openshift-web-console-smoke-test:latest
+  - name: web-console-smoke-test
+    image: benjaminapetersen/web-console-smoke-test:latest
     ports:
     - containerPort: 3000
       protocol: TCP
-    imagePullPolicy: IfNotPresent
+      imagePullPolicy: IfNotPresent
     env:
     # update the IP to <machine-ip>, wherever the console is running
     - name: CONSOLE_URL
       value: https://192.168.1.69:8443
     - name: TEST_INTERVAL_MINUTES
       value: '2'
+    volumeMounts:
+      - mountPath: /etc/tls-certs
+        name: web-console-smoke-test-serving-cert
+        readOnly: true
+  volumes:
+  - name: web-console-smoke-test-serving-cert
+    secret:
+      defaultMode: 400
+      secretName: web-console-smoke-test-serving-cert

--- a/kube/secrets/secret-tls.yaml
+++ b/kube/secrets/secret-tls.yaml
@@ -1,0 +1,26 @@
+# Prefer the `service.alpha.openshift.io/serving-cert-secret-name` annotation
+# on the service instead of manually creating a secret.
+#
+# If you need to manually create a secret, this file is
+# just for reference.  Use the following commands to
+# generate the appropriate secret:
+#
+# ./make_cert.sh
+# - this should generate /tls/cert.pem & /tls/key.pem & remove the passphrase
+# then, using kubectl or oc:
+# kubectl create secret tls --cert ./tls/cert.pem --key ./tls/key.pem -o yaml
+# oc create secret tls --cert ./tls/cert.pem --key ./tls/key.pem -o yaml
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: web-console-smoke-test-serving-cert
+type: Opaque
+data:
+  # Do not put actual certificate data here & commit to source control.
+  # your secret would not be very secret then, would it?
+  #
+  # these key names will be the file names if the secret is mounted on disk
+  # via a volume mount
+  tls.crt: cert goes here!  generate this, don't commit.
+  tls.key: cert goes here!  generate this, don't commit.

--- a/kube/service/smoke-test.yml
+++ b/kube/service/smoke-test.yml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-console-smoke-test-service
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
+      # TODO:
+      # don't we need these annotations, just like the web-console?
+      # https://github.com/openshift/origin/blob/master/install/origin-web-console/console-template.yaml#L127
+      # prometheus.io/scrape: "true"
+      # prometheus.io/scheme: https
+spec:
+  ports:
+  - name: web
+    protocol: TCP
+    port: 443
+    targetPort: 3000
+    nodePort: 0
+  selector:
+    app: web-console-smoke-test
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}

--- a/kube/service/smoke-test.yml
+++ b/kube/service/smoke-test.yml
@@ -4,11 +4,8 @@ metadata:
   name: web-console-smoke-test-service
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
-      # TODO:
-      # don't we need these annotations, just like the web-console?
-      # https://github.com/openshift/origin/blob/master/install/origin-web-console/console-template.yaml#L127
-      # prometheus.io/scrape: "true"
-      # prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: https
 spec:
   ports:
   - name: web

--- a/kube/smoke-test-list.yaml
+++ b/kube/smoke-test-list.yaml
@@ -6,22 +6,22 @@ items:
 - kind: Deployment
   apiVersion: apps/v1
   metadata:
-    name: openshift-web-console-smoke-test-deployment
+    name: web-console-smoke-test-deployment
     labels:
-      app: openshift-web-console-smoke-test
+      app: web-console-smoke-test
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: openshift-web-console-smoke-test
+        app: web-console-smoke-test
     template:
       metadata:
         labels:
-          app: openshift-web-console-smoke-test
+          app: web-console-smoke-test
       spec:
         containers:
-        - name: openshift-web-console-smoke-test
-          image: benjaminapetersen/openshift-web-console-smoke-test:latest
+        - name: web-console-smoke-test
+          image: benjaminapetersen/web-console-smoke-test:latest
           imagePullPolicy: IfNotPresent
           env:
           - name: CONSOLE_URL
@@ -34,7 +34,9 @@ items:
 - kind: Service
   apiVersion: v1
   metadata:
-    name: openshift-web-console-smoke-test-service
+    name: web-console-smoke-test-service
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
   spec:
     ports:
     - name: web
@@ -43,7 +45,7 @@ items:
       targetPort: 3000
       nodePort: 0
     selector:
-      app: openshift-web-console-smoke-test
+      app: web-console-smoke-test
     type: ClusterIP
     sessionAffinity: None
   status:

--- a/make_dev_crt.sh
+++ b/make_dev_crt.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+mkdir -p "${DIR}/.tmp";
+mkdir -p "${PWD}/tls";
+
+# generate
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -keyout "${DIR}/.tmp/key.pem" \
+  -out "${DIR}/.tmp/cert.pem" \
+  -days 365
+
+# remove passphrase
+openssl rsa \
+  -in "${DIR}/.tmp/key.pem" \
+  -out "${DIR}/.tmp/newkey.pem" \
+  && mv "${DIR}/.tmp/newkey.pem" "${DIR}/.tmp/key.pem"
+
+# final resting place
+mv "${DIR}/.tmp/key.pem" "${PWD}/tls/tls.key"
+mv "${DIR}/.tmp/cert.pem" "${PWD}/tls/tls.crt"

--- a/openshift/smoke-test.yaml
+++ b/openshift/smoke-test.yaml
@@ -1,0 +1,122 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: web-console-smoke-test-template
+  annotations:
+    openshift.io/display-name: Web Console Smoke Test
+    iconClass: icon-openshift
+    tags: openshift,infra
+    # TODO: update this URL when we migrate up the repo
+    openshift.io/documentation-url: https://github.com/benjaminapetersen/origin-web-console-smoke-test
+    openshift.io/support-url: https://access.redhat.com
+    openshift.io/provider-display-name: Red Hat, Inc.
+    description: >
+      Runs smoke tests in a headless browser against the web console at a provided URL.
+
+      For more information about using this template, see
+      https://github.com/benjaminapetersen/origin-web-console-smoke-test/blob/master/README.md
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-console-smoke-test
+    namespace: ${NAMESPACE}
+    labels:
+      app: web-console-smoke-test
+  spec:
+    # replica set
+    replicas: ${REPLICA_COUNT}
+    # selector = how the deployment finds pods to manage
+    selector:
+      matchLabels:
+        app: web-console-smoke-test
+    template:
+      metadata:
+        labels:
+          app: web-console-smoke-test
+      spec:
+        containers:
+        - name: web-console-smoke-test
+          image: ${IMAGE}
+          imagePullPolicy: ${PULL_POLICY}
+          env:
+          - name: TOKEN
+            value: ${TOKEN}
+          - name: CONSOLE_URL
+            value: ${CONSOLE_URL}
+          - name: CONSOLE_USER
+            value: ${CONSOLE_USER}
+          - name: CONSOLE_PASSWORD
+            value: ${CONSOLE_PASSWORD}
+          - name: TEST_INTERVAL_MINUTES
+            value: ${TEST_INTERVAL_MINUTES}
+          ports:
+          - containerPort: 3000
+          restartPolicy: Always
+          volumeMounts:
+            - mountPath: /etc/tls-certs
+              name: web-console-smoke-test-serving-cert
+              readOnly: true
+        volumes:
+        - name: web-console-smoke-test-serving-cert
+          secret:
+            defaultMode: 400
+            secretName: web-console-smoke-test-serving-cert
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: web-console-smoke-test
+    namespace: ${NAMESPACE}
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
+        # TODO:
+        # don't we need these annotations, just like the web-console?
+        # https://github.com/openshift/origin/blob/master/install/origin-web-console/console-template.yaml#L127
+        # prometheus.io/scrape: "true"
+        # prometheus.io/scheme: https
+  spec:
+    ports:
+    - name: web
+      protocol: TCP
+      port: 443
+      targetPort: 3000
+      nodePort: 0
+    selector:
+      app: web-console-smoke-test
+    type: ClusterIP
+    sessionAffinity: None
+  status:
+    loadBalancer: {}
+parameters:
+- name: IMAGE
+# TODO: update this URL when we migrate up the repo
+  value: benjaminapetersen/origin-web-console-smoke-test:latest
+- name: NAMESPACE
+  # This namespace cannot be changed. Only `openshift-web-console-smoke-test` is supported.
+  value: openshift-web-console-smoke-test
+- name: REPLICA_COUNT
+  value: "1"
+- name: PULL_POLICY
+  value: IfNotPresent
+- name: CONSOLE_URL
+  description: The location of the web console, in the format of https://<machine-ip>:8443
+  # TODO: can we default this? probably not.
+  required: true
+- name: CONSOLE_USER
+  description: An optional username
+- name: CONSOLE_PASSWORD
+  description: An optional password
+- name: TOKEN
+  description: >
+    A token to override the default flow.
+
+    If used, this should be an OAuth token provided as a string,
+    for the purpose of bypassing the oauth login flow and/or not use a
+    token from a service account.
+
+    Note that the default way to run this smoke test should be to let the
+    tests use a service account token provided by the Service annotation.
+- name: TEST_INTERVAL_MINUTES
+  description: An optional time interval to run tests, defaults to 2

--- a/openshift/smoke-test.yaml
+++ b/openshift/smoke-test.yaml
@@ -71,11 +71,8 @@ objects:
     namespace: ${NAMESPACE}
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
-        # TODO:
-        # don't we need these annotations, just like the web-console?
-        # https://github.com/openshift/origin/blob/master/install/origin-web-console/console-template.yaml#L127
-        # prometheus.io/scrape: "true"
-        # prometheus.io/scheme: https
+      prometheus.io/scrape: "true"
+      prometheus.io/scheme: https
   spec:
     ports:
     - name: web

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('./helpers/logger');
+
 const
   protocol = 'https',
   defaultHost = '127.0.0.1',
@@ -9,16 +11,20 @@ const
   loginUrl = `${baseUrl}/login`,
   authRedirectUrl = `${baseUrl}/oauth/authorize?client_id=openshift-web-console&response_type=token&state=`;
 
-const SERVICE_ACCOUNT_TOKEN = (
+
+const KEY_PATH = '/etc/tls-certs/tls.key';
+const CRT_PATH = '/etc/tls-certs/tls.crt';
+
+const TOKEN = (
   // if the user passes in a token as an env var, use that
   process.env.TOKEN ||
   // otherwise fallback to our script to search for a
   // service acct token, which should also be provided as
   // an env var
   process.env.SERVICE_ACCOUNT_TOKEN
-)
+);
 const auth = {
-  token: SERVICE_ACCOUNT_TOKEN
+  token: TOKEN
 };
 
 // Default test interval is 5 minutes
@@ -30,9 +36,15 @@ const user = {
 };
 
 if(!process.env.CONSOLE_URL) {
-  console.log(`CONSOLE_URL is not defined, using ${baseUrl}`);
+  logger.sync.log(`CONSOLE_URL is not defined, using ${baseUrl}`);
 } else {
-  console.log(`CONSOLE_URL is ${baseUrl}`);
+  logger.sync.log(`CONSOLE_URL is ${baseUrl}`);
+}
+
+if(process.env.TOKEN) {
+  logger.sync.log(`TOKEN is ${process.env.TOKEN.substr(0,10)}***(redacted)`);
+} else if(process.env.SERVICE_ACCOUNT_TOKEN) {
+  logger.sync.log(`SERVICE_ACCOUNT_TOKEN is ${process.env.SERVICE_ACCOUNT_TOKEN.substr(0,10)}***(redacted)`);
 }
 
 module.exports = {
@@ -43,5 +55,9 @@ module.exports = {
   isMac: /^darwin/.test(process.platform),
   test_interval,
   user,
-  auth
+  auth,
+  tls: {
+    keyPath: KEY_PATH,
+    crtPath: CRT_PATH
+  }
 };

--- a/test/helpers/doLogin.js
+++ b/test/helpers/doLogin.js
@@ -29,6 +29,7 @@ const withOauthForm = (name = env.user.name, pass = env.user.pass) => {
 
 
 const withTokenInjectedIntoLocalStorage = (token, username) => {
+  // username is likely arbitrary, but may come in from env vars
   username = username || process.env.CONSOLE_USER || 'e2e-user';
   const date = new Date(),
         year = date.getFullYear(),
@@ -109,7 +110,7 @@ const viaRedirectWithEncodedState = (token) => {
   logger.log('doLogin.viaRedirectWithEncodedState()', simulatedRedirectUrl);
   browser.get(simulatedRedirectUrl);
   const catalogPage = new CatalogPage();
-  console.log('catalog url:', catalogPage.getUrl());
+  logger.log('catalog url:', catalogPage.getUrl());
   browser.sleep(5000);
 };
 

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -43,7 +43,10 @@ exports.config = {
   // TODO: update docs to show flag --spec='spec/to/run.spec.js'
   // as we may want to use different flows in different environments.
   // specs: ['spec/login-with-oauth-flow.spec.js'],
+  // protractor --specs 'test/foo.spec.js'
   specs: ['spec/login-with-service-account-token.spec.js'],
+  // protractor  --suite 'suite-name'
+  // suite: {}
   logLevel: 'DEBUG', // 'ERROR'|'WARN'|'INFO'|'DEBUG'
   framework: 'jasmine',
   jasmineNodeOpts: {
@@ -73,14 +76,14 @@ exports.config = {
     browser.ignoreSynchronization = true;
 
     // nope, not in node.js land anymore...
-    // console.log('look for data....');
+    // logger.sync.log('look for data....');
     // return new Promise(function(resolve, reject) {
     //   fs.readFile(secretPath, (err, data) => {
     //     if(data) {
-    //       console.log('data?', data);
+    //       logger.sync.log('data?', data);
     //       resolve();
     //     } else {
-    //       console.log('no data', err);
+    //       logger.sync.log('no data', err);
     //       reject();
     //     }
     //   });

--- a/test/spec/login-with-service-account-token.spec.js
+++ b/test/spec/login-with-service-account-token.spec.js
@@ -5,23 +5,17 @@ const doLogin = require('../helpers/doLogin');
 const CatalogPage = require('../pageobjects/catalog');
 const LocalStorage = require('../pageobjects/localStorage');
 const timing = require('../helpers/timing');
+const logger = require('../helpers/logger');
 
 beforeEach(() => {
-  // TODO: just set in conf onPrepare() ?
+  // should be set in protractor.conf onPrepare()
   browser.ignoreSynchronization = true;
 });
 
 describe('Openshift login page', () => {
   describe('bypass OAuth with service account token', () => {
-    //
-    // NOTE: this will not run locally if you manually $(yarn bin)/protractor protractor.conf.js.
-    // A service account will only be created if you deploy the kube/pod.yaml within openshift,
-    // either via `oc create -f` or using the import yaml feature in the web console.
     it('should bypass the login flow by injecting a service account token into localStorage', () => {
-      // to simulate a login, run the console locally or otherwise & do the auth flow,
-      // then copy LocalStorageUserStore.token & paste as a string here.
-      var hardCodedToken = null;
-      doLogin.withTokenInjectedIntoLocalStorage(hardCodedToken);
+      doLogin.withTokenInjectedIntoLocalStorage();
       const catalogHeading = element(by.css('h1'));
       expect(catalogHeading.getText()).toBe('Browse Catalog');
     });


### PR DESCRIPTION
Fixes #18
Fixes #22 
Fixes #35 

So the flow:

````bash 
# generate a certificate 
# can use this script or diy, whatever you prefer:
# the script will remove the passphrase to make it a little easier to use:
./make_cert.sh 
# create a secret using the generated certs files:
oc create secret tls tls-certs --cert=tls/cert.pem --key=tls/key.pem -o yaml
# create the deployment after the secret, otherwise it will fail as 
# it expects the secret to be mounted as a volume:
oc create -f kube/deployments/smoke-test.yaml
```

Verify by checking your `deployment` in the console.  You should be able to drill down to the `pod` and see things in the logs.  Can also use `oc` if you prefer :) 

If the `secret` doesn't mount the pod won't start.  I've noticed it hangs indefinitely, and seems to have trouble deleting the pod, deployment, project.  Not sure if there is a bug here.

- [ ] TODO: update the `README.md` when this is stable.