### PR TITLE
Add catch block to page.js

### DIFF
--- a/test/pageobjects/page.js
+++ b/test/pageobjects/page.js
@@ -14,7 +14,9 @@ const waitFor = function(expected) {
 };
 
 const goTo = function(uri) {
-  return browser.get(uri).then(() =>  waitFor(uri));
+  return browser.get(uri).then(() =>  waitFor(uri)).catch(() => {
+    logger.error(`Failed to navigate to ${browser.getCurrentUrl()}`);
+  });
 };
 
 class Page {


### PR DESCRIPTION
@jhadvig 

This should help take care of some mysterious navigation errors when the browser fails to load a page (but protractor itself doesn't indicate why or what it was attempting to navigate to).

Example error without the `.catch()` shows that you can't really debug, `invalid URL` is not helpful.

```
 ✗ should bypass the login flow by injecting a service account token into localStorage
        - Failed: unknown error: unhandled inspector error: {"code":-32000,"message":"Cannot navigate to invalid URL"}
          (Session info: chrome=65.0.3325.181)
          (Driver info: chromedriver=2.37.544337 (8c0344a12e552148c185f7d5117db1f28d6c9e85),platform=Mac OS X 10.13.3 x86_64)
```