### PR TITLE
Reset fail counter on success

### DIFF
--- a/openshift/smoke-test.yaml
+++ b/openshift/smoke-test.yaml
@@ -92,7 +92,7 @@ parameters:
   description: The location of the web console, in the format of https://<console-public-url>:8443
   required: true
 - name: TEST_INTERVAL_MINUTES
-  description: An optional time interval to run tests, defaults to 2
+  description: An optional time interval to run tests, defaults to 5
 - name: SELF_SIGN_CERT
   description: Indicator to obtain self-signed certificate from web-console upon testing. Defaults to true so the self-signed cert is obrained.
   value: "true"

--- a/test/server.js
+++ b/test/server.js
@@ -45,6 +45,7 @@ const process = (data) => {
   data.testsuites.testsuite.forEach((suite) => {
     if(suite.$.failures === '0') {
       successCounter.inc();
+      failCounter.reset();
     } else {
       failCounter.inc();
     }


### PR DESCRIPTION
While putting together PR for [cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator) repo, that will be responsible for scraping metrics, I found out that we are missing, what should determine that web-console is in unavailable. 
So I propose following logic:
1., when Prometheus will be notified for the first time that the test failed, we'll increment `failCounter` and Prometheus will raise alert with `warning` severity
1.a, if the first test fail will be followed by additional one, we'll increment `failCounter` and  the an `critical` severity alert will be risen.
1.b, if after the first failed test a successful test will follow, then we'll reset the `failCounter`.

+ updated the ENV description since the default value is 5 minutes.

@benjaminapetersen PTAL